### PR TITLE
Update docker container port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,3 +20,4 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Bug fixes.
+- For running the docker container, the docker compose file by default is using port 8888. This is usually the default port used by Jupyter which we almost all are already using this port. Assign another port in the docker compose, for more convenience and ease of reproducibility.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ cp -r report/_build/html/* docs
 
 ### Adding a New Dependency
 
-1. **Modify Dockerfile**: Add the new dependency to the `Dockerfile`. Create a new branch for these changes.
+1. **Modify Dockerfile**: Add the new dependency to the `Dockerfile`. Create a new branch for these changes. 
 
 2. **Build Docker Image Locally**: Ensure the Docker image builds and runs correctly on your local machine.
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The analysis leverages the *Titanic Passenger Survival Data Set*, which is a com
     docker compose up
     ```
 
-2. **Access Jupyter Lab**: After running the command, a URL should appear in the terminal. It will look something like `http://127.0.0.1:8888/lab?token=`. Copy and paste this URL into your web browser to access Jupyter Lab.
+2. **Access Jupyter Lab**: After running the command, a URL should appear in the terminal. It will look something like `http://127.0.0.1:8888/lab?token=`. Copy and paste this URL into your web browser to access Jupyter Lab. Replace the port number with the one (9000) specified in the `docker-compose.yml` file. The token is a unique identifier that is generated each time you run the Docker container. It is used to authenticate your access to Jupyter Lab.
 
  ![Jupyter Container Web App Launch URL](img/jupyter-container-web-app-launch-url.png)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   titanic_lr_analysis:
     image: sampsonyu/dsci522-group-dockerfile:af85f1d
     ports:
-      - "8888:8888"
+      - "9000:8888"
     volumes:
       - .:/home/jovyan/work
     deploy:


### PR DESCRIPTION
For running the docker container, the docker compose file by default is using port 8888. This is usually the default port used by Jupyter which we almost all are already using this port. Assign port 9000 in the docker compose, for more convenience and ease of reproducibility.

http://127.0.0.1:8888/lab?token=2438683081891616e4b9927a76d90544f5828817892d1e0e

Should use the following URL to interact with docker container:
http://127.0.0.1:9000/lab?token=2438683081891616e4b9927a76d90544f5828817892d1e0e